### PR TITLE
downgrade version due to build error on docker hub

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,5 @@
 ---
-version: "3.7"
+version: "3.6"
 
 services:
   sut:


### PR DESCRIPTION
fix "client version 1.38 is too new. Maximum supported API version is 1.37"